### PR TITLE
промяна на тип на х във функцията foldr

### DIFF
--- a/lists/lists_tests.cpp
+++ b/lists/lists_tests.cpp
@@ -150,7 +150,7 @@ template <typename T, typename R, typename I>
 R foldr(I it, R (*op)(T, R), R const& nv) {
 	if (!it)
 		return nv;
-	int x = *it++;
+	T x = *it++;
 	return op(x, foldr(it, op, nv));
 }
 


### PR DESCRIPTION
Типът на променливата х да бъде T, тъй като това е общият вид на функцията и при това op очаква операнд с тип T и на негово място се подава х
